### PR TITLE
Add Desktop notifications

### DIFF
--- a/src/Main.tsx
+++ b/src/Main.tsx
@@ -15,11 +15,13 @@ import PrCard from './components/PrCard';
 import ConfigDrawer from './components/ConfigDrawer';
 import { useConfig } from './contexts/ConfigProvider';
 import { useCountdownProgress } from './hooks/useCountdown';
+import useDesktopNotifications from './hooks/useDesktopNotifications';
 
 export default function Main() {
   const token = useGithubToken().token;
   const { repos, autoRefresh } = useConfig().config;
-  const { runTime, data, refresh } = usePrData();
+  const { runTime, data, refresh, rawData } = usePrData();
+  useDesktopNotifications(rawData);
   const progress = useCountdownProgress(runTime, runTime + autoRefresh * 1000);
   const [drawerOpen, setDrawerOpen] = useBoolean();
 

--- a/src/components/ConfigDrawer.tsx
+++ b/src/components/ConfigDrawer.tsx
@@ -70,6 +70,20 @@ export default function ConfigDrawer({
     /[A-Za-z0-9\-_]+\/[A-Za-z0-9\-_]+/
   );
 
+  const requestNotificationPermission = async () => {
+    // Check if the browser supports notifications
+    if (!('Notification' in window)) {
+      alert('This browser does not support notifications.');
+      return false;
+    }
+    const permission = await Notification.requestPermission();
+    if (permission !== 'granted') {
+      alert("Notification permission denied, can't enable notifications.");
+      return false;
+    }
+    return true;
+  };
+
   return (
     <>
       <Modal isOpen={newRepoModalOpen} onClose={onNewRepoModalClose}>
@@ -147,6 +161,7 @@ export default function ConfigDrawer({
                 </div>
 
                 <Checkbox
+                  defaultChecked={config.showMeOnly}
                   checked={config.showMeOnly}
                   onChange={(e) =>
                     setConfig((c) => ({ ...c, showMeOnly: e.target.checked }))
@@ -154,6 +169,36 @@ export default function ConfigDrawer({
                 >
                   Show me only
                 </Checkbox>
+
+                <Checkbox
+                  defaultChecked={config.notificationsEnabled}
+                  checked={config.notificationsEnabled}
+                  onChange={async (e) => {
+                    if (e.target.checked)
+                      e.target.checked = await requestNotificationPermission();
+                    setConfig((c) => ({
+                      ...c,
+                      notificationsEnabled: e.target.checked,
+                    }));
+                  }}
+                >
+                  Desktop notifications
+                </Checkbox>
+                {config.notificationsEnabled && (
+                  <Checkbox
+                    defaultChecked={config.notifyForComments}
+                    checked={config.notifyForComments}
+                    onChange={(e) =>
+                      setConfig((c) => ({
+                        ...c,
+                        notifyForComments: e.target.checked,
+                      }))
+                    }
+                  >
+                    Notify for comments
+                  </Checkbox>
+                )}
+
                 <Button onClick={toggleColorMode}>
                   Toggle {colorMode === 'light' ? 'Dark' : 'Light'}
                 </Button>

--- a/src/contexts/ConfigProvider.tsx
+++ b/src/contexts/ConfigProvider.tsx
@@ -4,6 +4,8 @@ import { Grouping } from '../types';
 
 type Config = {
   showMeOnly: boolean;
+  notificationsEnabled: boolean;
+  notifyForComments: boolean;
   grouping: Grouping;
   autoRefresh: number;
   repos: string[];
@@ -16,6 +18,8 @@ type ConfigContextType = {
 
 const defaultConfig: Config = {
   showMeOnly: false,
+  notificationsEnabled: false,
+  notifyForComments: false,
   grouping: 'repo',
   autoRefresh: 300,
   repos: [],

--- a/src/hooks/useDesktopNotifications.ts
+++ b/src/hooks/useDesktopNotifications.ts
@@ -1,0 +1,144 @@
+import { useEffect, useState } from 'react';
+import { useConfig } from '../contexts/ConfigProvider';
+import { PrData } from '../types';
+import useLogin from './useLogin';
+
+export default function useDesktopNotifications(rawData: PrData[]) {
+  const login = useLogin();
+  const { notificationsEnabled, notifyForComments } = useConfig().config;
+  const [previousData, setPreviousData] = useState<PrData[]>(rawData);
+
+  useEffect(() => {
+    const notifyOfUpdates = () => {
+      if (
+        !login ||
+        !notificationsEnabled ||
+        Notification.permission !== 'granted' ||
+        !previousData.length ||
+        !rawData.length ||
+        previousData.some((p) => p.loading)
+      )
+        return;
+
+      // Notify if any PRs have become ready for review
+      const currentReadyForReview = getPrsReadyForReview(rawData, login);
+      const previousReadyForReview = getPrsReadyForReview(previousData, login);
+      const newPrsReadyForReview = currentReadyForReview
+        .filter(
+          (pr) =>
+            !previousReadyForReview.some(
+              (prevPr) => prevPr.pr.number === pr.pr.number
+            )
+        )
+        .filter((pr) => pr.pr.user?.login !== login);
+      for (const newPr of newPrsReadyForReview) {
+        notify(
+          'PR ready',
+          `${newPr.pr.title} is ready for review`,
+          newPr.pr.html_url,
+          newPr.pr.user?.avatar_url
+        );
+      }
+
+      // Notify if any of our PRs have new reviews
+      const currentReviews = getReviews(rawData, login);
+      const previousReviews = getReviews(previousData, login);
+      const newReviews = currentReviews.filter(
+        (r) => !previousReviews.some((prevR) => prevR.id === r.id)
+      );
+      for (const review of newReviews) {
+        notify(
+          review.state,
+          `${review.user?.login} reviewed: ${review.body}`,
+          review.html_url,
+          review.user?.avatar_url
+        );
+      }
+
+      if (notifyForComments) {
+        // Notify if any of our PRs have new comments
+        const currentComments = getComments(rawData, login);
+        const previousComments = getComments(previousData, login);
+        const newComments = currentComments.filter(
+          (c) => !previousComments.some((prevC) => prevC.id === c.id)
+        );
+        for (const comment of newComments) {
+          notify(
+            'New comment',
+            `${comment.user?.login} commented: ${comment.body}`,
+            comment.html_url,
+            comment.user?.avatar_url
+          );
+        }
+      }
+    };
+
+    notifyOfUpdates();
+
+    setPreviousData(rawData);
+  }, [rawData, notificationsEnabled, previousData, login, notifyForComments]);
+
+  const notify = (
+    title: string,
+    body: string,
+    clickUrl: string,
+    iconUrl = '/logo192.png'
+  ) => {
+    const notification = new Notification(title, {
+      body,
+      icon: iconUrl,
+    });
+    notification.onclick = () => {
+      // window.focus();
+      window.open(clickUrl, '_blank')?.opener?.focus();
+      notification.close();
+    };
+  };
+}
+
+const getPrsReadyForReview = (data: PrData[], login: string) =>
+  data.filter(
+    (pr) =>
+      pr.pr.state === 'open' &&
+      !pr.pr.draft &&
+      !pr.pr.merged_at &&
+      (!Object.values(pr.reviews ?? {}).some(
+        (r) => r?.state === 'CHANGES_REQUESTED'
+      ) ||
+        pr.pr.requested_reviewers?.some((r) => r.login === login))
+  );
+
+const getComments = (data: PrData[], login: string) => {
+  let comments = [];
+  for (const pr of data) {
+    if (pr.pr.state !== 'open' || !!pr.pr.merged_at) continue;
+
+    // If it's not our pr only get comments in reply to our reviews or ones we're tagged in
+    let prComments = pr.comments?.filter((c) => c.user?.login !== login);
+    if (pr.pr.user?.login !== login)
+      prComments = prComments?.filter(
+        (c) => c.in_reply_to_id || c.body.includes(`@${login}`)
+      );
+
+    if (prComments?.length) comments.push(prComments);
+  }
+  return comments.flat();
+};
+
+const getReviews = (data: PrData[], login: string) => {
+  let reviews = [];
+  for (const pr of data) {
+    if (
+      pr.pr.state !== 'open' ||
+      !!pr.pr.merged_at ||
+      pr.pr.user?.login !== login
+    )
+      continue;
+
+    const prReviews = Object.values(pr.reviews || {}).filter(
+      (r) => r.user?.login !== login
+    );
+    if (prReviews?.length) reviews.push(prReviews);
+  }
+  return reviews.flat();
+};

--- a/src/hooks/usePrData.ts
+++ b/src/hooks/usePrData.ts
@@ -7,7 +7,7 @@ import { useConfig } from '../contexts/ConfigProvider';
 import { useGithubToken } from '../contexts/GithubTokenProvider';
 import fetchPrData from '../util/fetchPrData';
 
-function useRawPrData(): {
+export function useRawPrData(): {
   runTime: number;
   data: PrData[];
   refresh: () => void;
@@ -77,6 +77,7 @@ function useRawPrData(): {
 export default function usePrData(): {
   runTime: number;
   data: Array<{ label: string; data: PrData[] }>;
+  rawData: PrData[];
   refresh: () => void;
 } {
   const login = useLogin();
@@ -136,6 +137,7 @@ export default function usePrData(): {
   return {
     runTime,
     data: groupedData,
+    rawData: data,
     refresh,
   };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,5 +10,6 @@ export type PrData = {
     ]: Endpoints['GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews']['response']['data'][number];
   };
   commits?: Endpoints['GET /repos/{owner}/{repo}/pulls/{pull_number}/commits']['response']['data'];
+  comments?: Endpoints['GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews/{review_id}/comments']['response']['data'];
   loading: boolean;
 };

--- a/src/util/fetchPrData.ts
+++ b/src/util/fetchPrData.ts
@@ -5,7 +5,7 @@ import { PrData } from '../types';
 export default async function fetchPrData(
   token: string,
   pr: { owner: string; repo: string; number: number; login: string }
-): Promise<Required<Pick<PrData, 'reviews' | 'commits'>>> {
+): Promise<Required<Pick<PrData, 'reviews' | 'commits' | 'comments'>>> {
   const octokit = new Octokit({ auth: token });
 
   const reviews = octokit.rest.pulls
@@ -31,8 +31,19 @@ export default async function fetchPrData(
     })
     .then((res) => res.data);
 
-  return Promise.all([reviews, commits]).then(([reviews, commits]) => ({
-    reviews,
-    commits,
-  }));
+  const comments = octokit.rest.pulls
+    .listReviewComments({
+      owner: pr.owner,
+      repo: pr.repo,
+      pull_number: pr.number,
+    })
+    .then((res) => res.data);
+
+  return Promise.all([reviews, commits, comments]).then(
+    ([reviews, commits, comments]) => ({
+      reviews,
+      commits,
+      comments,
+    })
+  );
 }


### PR DESCRIPTION
**Problem:**
Githubs built in notifications leave a lot to be desired:
 - They are limited to just email or in-app (No desktop notification support)
 - We don't get fine grained control over the pull request notification events
 - The notifications are vague and just link to the relevant pr

**Proposed Solution**
Add desktop notification support into the review dashboard which will give us the following advantages:
 - Get notified while the browser is in the background
 - Give us more fine grained control over what triggers notifications
 - Give more detail on the notifications
 - Reduce time to actually view a notification
 
 **Implementation**
  - 

<img width="362" alt="image" src="https://github.com/daveallie/github-review-dashboard/assets/38173749/67ebb286-8dfb-4d80-b62b-50c354e0e552">
