### PR TITLE
Make the Card clickable

### DIFF
--- a/src/components/PrCard.tsx
+++ b/src/components/PrCard.tsx
@@ -41,6 +41,10 @@ export default function PrCard({
       u.login !== pr.user?.login && !Object.keys(reviews).includes(u.login),
   );
 
+  const navigateToPr = () => {
+    window.open(pr.html_url, '_blank');
+  }
+
   return (
     <Card opacity={pr.draft ? 0.5 : 1}>
       <CardHeader>
@@ -69,7 +73,7 @@ export default function PrCard({
           </Flex>
         </Flex>
       </CardHeader>
-      <CardBody>
+      <CardBody onClick={navigateToPr} _hover={{ cursor: 'pointer' }}>
         {loading ? (
           <Stack>
             <Flex gap={4} direction="row" alignItems="center">


### PR DESCRIPTION
When a PR is ready for review I mostly want to just navigate to the PR directly, and find myself having to use the direct link, rather than bonking my click into the general card. 

I'm proposing we make the body of our card clickable for easier use like so: 

https://github.com/daveallie/github-review-dashboard/assets/16897508/6d8d0dba-524d-4ad8-8eb5-34e118bf8d4b

I've made the `CardBody` clickable instead of the whole `Card` to respect the use case of our current `href` tags. 